### PR TITLE
Feat : Add `GetWorkSessionByUserId` API

### DIFF
--- a/src/modules/workSession/controller/workSession.controller.ts
+++ b/src/modules/workSession/controller/workSession.controller.ts
@@ -19,6 +19,8 @@ import { EndWorkSessionDto } from '../dto/end-work-session-dto';
 import { AuthGuardMiddleware } from '../../../middlewares/auth-guard.middleware';
 import { UpdateActiveTaskRequestDto } from '../dto/update-active-task-request-dto';
 import { UpdateActiveTaskServiceDto } from '../dto/update-active-task-service.dto';
+import { http } from 'winston';
+import { GetWorkSessionByUserIdDto } from '../dto/getWorkSessionByUserId.dto';
 
 @controller('/users/:userId/work-sessions', AuthGuardMiddleware)
 export class WorkSessionController {
@@ -26,6 +28,21 @@ export class WorkSessionController {
     @inject(TYPES.IWorkSessionService)
     private readonly workSessionService: IWorkSessionService,
   ) {}
+
+  @httpGet('/')
+  public async getWorkSessionsByUserId(
+    @requestParam('userId') userId: number,
+    _: Request,
+    res: Response,
+  ) {
+    const dto = new GetWorkSessionByUserIdDto();
+    dto.userId = userId;
+    const workSessions = await this.workSessionService.getWorkSessionByUserId(
+      dto,
+    );
+
+    return res.status(200).json({ workSessions });
+  }
 
   @httpGet('/latest')
   public async findLatestUnfinishedWorkSession(

--- a/src/modules/workSession/controller/workSession.controller.ts
+++ b/src/modules/workSession/controller/workSession.controller.ts
@@ -19,8 +19,7 @@ import { EndWorkSessionDto } from '../dto/end-work-session-dto';
 import { AuthGuardMiddleware } from '../../../middlewares/auth-guard.middleware';
 import { UpdateActiveTaskRequestDto } from '../dto/update-active-task-request-dto';
 import { UpdateActiveTaskServiceDto } from '../dto/update-active-task-service.dto';
-import { http } from 'winston';
-import { GetWorkSessionByUserIdDto } from '../dto/getWorkSessionByUserId.dto';
+import { getWorkSessionsByUserIdDto } from '../dto/getWorkSessionByUserId.dto';
 
 @controller('/users/:userId/work-sessions', AuthGuardMiddleware)
 export class WorkSessionController {
@@ -35,7 +34,7 @@ export class WorkSessionController {
     _: Request,
     res: Response,
   ) {
-    const dto = new GetWorkSessionByUserIdDto();
+    const dto = new getWorkSessionsByUserIdDto();
     dto.userId = userId;
     const workSessions = await this.workSessionService.getWorkSessionByUserId(
       dto,

--- a/src/modules/workSession/dto/getWorkSessionByUserId.dto.ts
+++ b/src/modules/workSession/dto/getWorkSessionByUserId.dto.ts
@@ -1,0 +1,6 @@
+import { IsNumber } from 'class-validator';
+
+export class GetWorkSessionByUserIdDto {
+  @IsNumber()
+  userId: number;
+}

--- a/src/modules/workSession/dto/getWorkSessionByUserId.dto.ts
+++ b/src/modules/workSession/dto/getWorkSessionByUserId.dto.ts
@@ -1,6 +1,6 @@
 import { IsNumber } from 'class-validator';
 
-export class GetWorkSessionByUserIdDto {
+export class getWorkSessionsByUserIdDto {
   @IsNumber()
   userId: number;
 }

--- a/src/modules/workSession/interfaces/IWorkSession.repository.ts
+++ b/src/modules/workSession/interfaces/IWorkSession.repository.ts
@@ -3,6 +3,7 @@ import { CreateWorkSessionDto } from '../dto/create-work-session.dto';
 import { FindLatestUnfinishedWorkSessionDto } from '../dto/find-latest-unfinished-work-session-dto';
 export interface IWorkSessionRepository {
   findOneById(workSessionId: number): Promise<WorkSession>;
+  findByUserId(userId: number): Promise<WorkSession[]>;
   findLatestUnfinished(
     findLatestUnfinishedWorkSessionDto: FindLatestUnfinishedWorkSessionDto,
   ): Promise<WorkSession | null>;

--- a/src/modules/workSession/interfaces/IWorkSession.service.ts
+++ b/src/modules/workSession/interfaces/IWorkSession.service.ts
@@ -4,7 +4,7 @@ import { EndWorkSessionDto } from '../dto/end-work-session-dto';
 import { FindLatestUnfinishedWorkSessionDto } from '../dto/find-latest-unfinished-work-session-dto';
 import { CreateWorkSessionServiceReturnDto } from '../dto/create-work-session-service-return-dto';
 import { UpdateActiveTaskServiceDto } from '../dto/update-active-task-service.dto';
-import { GetWorkSessionByUserIdDto } from '../dto/getWorkSessionByUserId.dto';
+import { getWorkSessionsByUserIdDto } from '../dto/getWorkSessionByUserId.dto';
 
 export interface IWorkSessionService {
   createWorkSession(
@@ -17,7 +17,7 @@ export interface IWorkSessionService {
   updateActiveTask(
     updateActiveTaskServiceDto: UpdateActiveTaskServiceDto,
   ): Promise<WorkSession>;
-  getWorkSessionByUserId(
-    getWorkSessionByUserIdDto: GetWorkSessionByUserIdDto,
+  getWorkSessionsByUserId(
+    getWorkSessionsByUserIdDto: getWorkSessionsByUserIdDto,
   ): Promise<WorkSession[]>;
 }

--- a/src/modules/workSession/interfaces/IWorkSession.service.ts
+++ b/src/modules/workSession/interfaces/IWorkSession.service.ts
@@ -4,6 +4,7 @@ import { EndWorkSessionDto } from '../dto/end-work-session-dto';
 import { FindLatestUnfinishedWorkSessionDto } from '../dto/find-latest-unfinished-work-session-dto';
 import { CreateWorkSessionServiceReturnDto } from '../dto/create-work-session-service-return-dto';
 import { UpdateActiveTaskServiceDto } from '../dto/update-active-task-service.dto';
+import { GetWorkSessionByUserIdDto } from '../dto/getWorkSessionByUserId.dto';
 
 export interface IWorkSessionService {
   createWorkSession(
@@ -16,4 +17,5 @@ export interface IWorkSessionService {
   updateActiveTask(
     updateActiveTaskServiceDto: UpdateActiveTaskServiceDto,
   ): Promise<WorkSession>;
+  getWorkSessionByUserId(getWorkSessionNyUserIdDto: GetWorkSessionByUserIdDto);
 }

--- a/src/modules/workSession/interfaces/IWorkSession.service.ts
+++ b/src/modules/workSession/interfaces/IWorkSession.service.ts
@@ -17,5 +17,7 @@ export interface IWorkSessionService {
   updateActiveTask(
     updateActiveTaskServiceDto: UpdateActiveTaskServiceDto,
   ): Promise<WorkSession>;
-  getWorkSessionByUserId(getWorkSessionNyUserIdDto: GetWorkSessionByUserIdDto);
+  getWorkSessionByUserId(
+    getWorkSessionByUserIdDto: GetWorkSessionByUserIdDto,
+  ): Promise<WorkSession[]>;
 }

--- a/src/modules/workSession/repository/workSession.repository.ts
+++ b/src/modules/workSession/repository/workSession.repository.ts
@@ -26,9 +26,34 @@ export class WorkSessionRepository implements IWorkSessionRepository {
     return await this.database.getRepository(WorkSession);
   }
 
+  /**
+   * Find WorkSession by Id
+   *
+   * @param {number} workSessionId
+   * @return {*}  {Promise<WorkSession>}
+   * @memberof WorkSessionRepository
+   */
   async findOneById(workSessionId: number): Promise<WorkSession> {
     const repo = await this.getWorkSessionRepo();
     return repo.findOneBy({ id: workSessionId });
+  }
+
+  /**
+   * Find WorkSessions by UserId
+   *
+   * @param {number} userId
+   * @return {*}  {Promise<WorkSession[]>}
+   * @memberof WorkSessionRepository
+   */
+  async findByUserId(userId: number): Promise<WorkSession[]> {
+    const repo = await this.getWorkSessionRepo();
+    return repo.find({
+      where: {
+        user: {
+          id: userId,
+        },
+      },
+    });
   }
 
   /**

--- a/src/modules/workSession/service/workSession.service.ts
+++ b/src/modules/workSession/service/workSession.service.ts
@@ -18,6 +18,7 @@ import { UpdateActiveTaskServiceDto } from '../dto/update-active-task-service.dt
 import { IListRepository } from '../../../modules/list/interface/IList.repository';
 import { ITabRepository } from '../../../modules/tab/interface/ITab.repository';
 import { ITaskRepository } from '../../../modules/task/interface/ITask.repository';
+import { GetWorkSessionByUserIdDto } from '../dto/getWorkSessionByUserId.dto';
 
 /**
  *
@@ -42,6 +43,29 @@ export class WorkSessionService implements IWorkSessionService {
     private readonly logger: Logger,
   ) {}
 
+  /**
+   * Get WorkSessions by UserId
+   *
+   * @param {GetWorkSessionByUserIdDto} getWorkSessionByUserIdDto
+   * @return {*}  {Promise<WorkSession[]>}
+   * @memberof WorkSessionService
+   */
+  async getWorkSessionByUserId(
+    getWorkSessionByUserIdDto: GetWorkSessionByUserIdDto,
+  ): Promise<WorkSession[]> {
+    const { userId } = getWorkSessionByUserIdDto;
+    try {
+      const workSessions = await this.workSessionRepository.findByUserId(
+        userId,
+      );
+      return workSessions;
+    } catch (error) {
+      this.logger.error(`Failed to get the work sessions. Error: ${error}`);
+      throw new InternalServerErrorException(
+        'Failed to get the work sessions.',
+      );
+    }
+  }
   /**
    * Get latest unfinished WorkSession
    *

--- a/src/modules/workSession/service/workSession.service.ts
+++ b/src/modules/workSession/service/workSession.service.ts
@@ -18,7 +18,7 @@ import { UpdateActiveTaskServiceDto } from '../dto/update-active-task-service.dt
 import { IListRepository } from '../../../modules/list/interface/IList.repository';
 import { ITabRepository } from '../../../modules/tab/interface/ITab.repository';
 import { ITaskRepository } from '../../../modules/task/interface/ITask.repository';
-import { GetWorkSessionByUserIdDto } from '../dto/getWorkSessionByUserId.dto';
+import { getWorkSessionsByUserIdDto } from '../dto/getWorkSessionByUserId.dto';
 
 /**
  *
@@ -46,14 +46,14 @@ export class WorkSessionService implements IWorkSessionService {
   /**
    * Get WorkSessions by UserId
    *
-   * @param {GetWorkSessionByUserIdDto} getWorkSessionByUserIdDto
+   * @param {GetWorkSessionByUserIdDto} getWorkSessionsByUserIdDto
    * @return {*}  {Promise<WorkSession[]>}
    * @memberof WorkSessionService
    */
-  async getWorkSessionByUserId(
-    getWorkSessionByUserIdDto: GetWorkSessionByUserIdDto,
+  async getWorkSessionsByUserId(
+    getWorkSessionsByUserIdDto: getWorkSessionsByUserIdDto,
   ): Promise<WorkSession[]> {
-    const { userId } = getWorkSessionByUserIdDto;
+    const { userId } = getWorkSessionsByUserIdDto;
     try {
       const workSessions = await this.workSessionRepository.findByUserId(
         userId,

--- a/src/modules/workSession/tests/workSession.controller.spec.ts
+++ b/src/modules/workSession/tests/workSession.controller.spec.ts
@@ -13,6 +13,13 @@ describe('WorkSession Controller Test', () => {
       .to(FakeWorkSessionService);
   });
 
+  describe('Get Work Sessions By User ID', () => {
+    it('should get all work sessions for a user', (done: jest.DoneCallback) => {
+      const userId = 1; // Replace with the user ID for testing
+      agent.get(`/users/${userId}/work-sessions`).expect(200, done);
+    });
+  });
+
   describe('Find Latest Unfinished Work Session', () => {
     it('should get the latest unfinished work session', (done: jest.DoneCallback) => {
       const userId = 1; // Replace with the user ID for testing

--- a/src/modules/workSession/tests/workSession.service.spec.ts
+++ b/src/modules/workSession/tests/workSession.service.spec.ts
@@ -15,6 +15,10 @@ import { IUserRepository } from '../../../modules/user/interfaces/IUser.reposito
 import { ITemplateRepository } from '../../../modules/template/interfaces/ITemplate.repository';
 import { fakeWorkSession } from '../../../../test/factory/workSession.factory';
 import { fakeTask } from '../../../../test/factory/task.factory';
+import { ITabRepository } from 'src/modules/tab/interface/ITab.repository';
+import { ITaskRepository } from 'src/modules/task/interface/ITask.repository';
+import { IListRepository } from 'src/modules/list/interface/IList.repository';
+import { GetWorkSessionByUserIdDto } from '../dto/getWorkSessionByUserId.dto';
 
 describe('WorkSession Service Test', () => {
   let workSessionService: WorkSessionService;
@@ -35,9 +39,17 @@ describe('WorkSession Service Test', () => {
     findOneById: jest.fn(() => Promise.resolve({ id: 1 })),
   } as unknown as IUserRepository;
 
-  const mockTemplateRepository: ITemplateRepository = {
-    // Mock any methods from the template repository if needed.
-  } as unknown as ITemplateRepository;
+  const mockTabRepository: ITabRepository = {
+    findOneById: jest.fn(() => Promise.resolve({ id: 1 })),
+  } as unknown as ITabRepository;
+
+  const mockListRepository: IListRepository = {
+    findOneById: jest.fn(() => Promise.resolve({ id: 1 })),
+  } as unknown as IListRepository;
+
+  const mockTaskRepository: ITaskRepository = {
+    findOneById: jest.fn(() => Promise.resolve({ id: 1 })),
+  } as unknown as ITaskRepository;
 
   const mockLogger: Logger = {
     error: jest.fn(),
@@ -48,9 +60,23 @@ describe('WorkSession Service Test', () => {
     workSessionService = new WorkSessionService(
       mockUserRepository,
       mockWorkSessionRepository,
-      mockTemplateRepository,
+      mockTabRepository,
+      mockListRepository,
+      mockTaskRepository,
       mockLogger,
     );
+  });
+
+  describe('Get Work Sessions By User ID', () => {
+    it('Should get all work sessions for a user', async () => {
+      const getWorkSessionByUserIdDto: GetWorkSessionByUserIdDto = {
+        userId: 1,
+      };
+      const response = await workSessionService.getWorkSessionByUserId(
+        getWorkSessionByUserIdDto,
+      );
+      expect(response).toEqual([fakeWorkSessionA]);
+    });
   });
 
   describe('Create WorkSession', () => {
@@ -79,6 +105,8 @@ describe('WorkSession Service Test', () => {
       expect(response.workSession).toEqual(fakeWorkSessionA);
     });
   });
+
+  describe('Update Active Task', () => {});
 
   describe('Get Latest Unfinished WorkSession', () => {
     it('Should get the latest unfinished work session', async () => {

--- a/src/modules/workSession/tests/workSession.service.spec.ts
+++ b/src/modules/workSession/tests/workSession.service.spec.ts
@@ -1,32 +1,27 @@
 import 'reflect-metadata';
 import { WorkSessionService } from '../service/workSession.service';
 import { IWorkSessionRepository } from '../interfaces/IWorkSession.repository';
-import { WorkSession } from '../entity/workSession.entity';
 import { CreateWorkSessionServiceDto } from '../dto/create-work-session-service-dto';
 import { EndWorkSessionDto } from '../dto/end-work-session-dto';
 import { FindLatestUnfinishedWorkSessionDto } from '../dto/find-latest-unfinished-work-session-dto';
-import { CreateWorkSessionServiceReturnDto } from '../dto/create-work-session-service-return-dto';
 import {
   NotFoundException,
   InternalServerErrorException,
 } from '../../../common/errors/all.exception';
 import { Logger } from '../../../common/services/logger.service';
 import { IUserRepository } from '../../../modules/user/interfaces/IUser.repository';
-import { ITemplateRepository } from '../../../modules/template/interfaces/ITemplate.repository';
 import { fakeWorkSession } from '../../../../test/factory/workSession.factory';
 import { fakeTask } from '../../../../test/factory/task.factory';
 import { ITabRepository } from 'src/modules/tab/interface/ITab.repository';
 import { ITaskRepository } from 'src/modules/task/interface/ITask.repository';
 import { IListRepository } from 'src/modules/list/interface/IList.repository';
-import { GetWorkSessionByUserIdDto } from '../dto/getWorkSessionByUserId.dto';
+import { getWorkSessionsByUserIdDto } from '../dto/getWorkSessionByUserId.dto';
 
 describe('WorkSession Service Test', () => {
   let workSessionService: WorkSessionService;
 
   // Dummy data implementation
   const fakeWorkSessionA = fakeWorkSession();
-  const fakeTaskActive = fakeTask(true);
-  const fakeTaskInActive = fakeTask(false);
 
   // Mock repositories and logger
   const mockWorkSessionRepository: IWorkSessionRepository = {
@@ -69,11 +64,11 @@ describe('WorkSession Service Test', () => {
 
   describe('Get Work Sessions By User ID', () => {
     it('Should get all work sessions for a user', async () => {
-      const getWorkSessionByUserIdDto: GetWorkSessionByUserIdDto = {
+      const getWorkSessionsByUserIdDto: getWorkSessionsByUserIdDto = {
         userId: 1,
       };
-      const response = await workSessionService.getWorkSessionByUserId(
-        getWorkSessionByUserIdDto,
+      const response = await workSessionService.getWorkSessionsByUserId(
+        getWorkSessionsByUserIdDto,
       );
       expect(response).toEqual([fakeWorkSessionA]);
     });

--- a/test/service/fakeWorkSession.service.ts
+++ b/test/service/fakeWorkSession.service.ts
@@ -6,9 +6,16 @@ import { FindLatestUnfinishedWorkSessionDto } from '../../src/modules/workSessio
 import { CreateWorkSessionServiceReturnDto } from '../../src/modules/workSession/dto/create-work-session-service-return-dto';
 import { WorkSession } from '../../src/modules/workSession/entity/workSession.entity';
 import { fakeWorkSession } from '../factory/workSession.factory';
+import { GetWorkSessionByUserIdDto } from 'src/modules/workSession/dto/getWorkSessionByUserId.dto';
+import { UpdateActiveTaskServiceDto } from 'src/modules/workSession/dto/update-active-task-service.dto';
 
 @injectable()
 export class FakeWorkSessionService implements IWorkSessionService {
+  updateActiveTask(
+    updateActiveTaskServiceDto: UpdateActiveTaskServiceDto,
+  ): Promise<WorkSession> {
+    throw new Error('Method not implemented.');
+  }
   createWorkSession(
     createWorkSessionServiceDto: CreateWorkSessionServiceDto,
   ): Promise<CreateWorkSessionServiceReturnDto> {
@@ -17,6 +24,12 @@ export class FakeWorkSessionService implements IWorkSessionService {
       isUnfinished: true,
       workSession: fakeWorkSession(), // Using the factory to generate a WorkSession
     });
+  }
+
+  getWorkSessionByUserId(
+    getWorkSessionNyUserIdDto: GetWorkSessionByUserIdDto,
+  ): Promise<WorkSession[]> {
+    return Promise.resolve([fakeWorkSession()]);
   }
 
   getLatestUnfinishedWorkSession(

--- a/test/service/fakeWorkSession.service.ts
+++ b/test/service/fakeWorkSession.service.ts
@@ -6,7 +6,7 @@ import { FindLatestUnfinishedWorkSessionDto } from '../../src/modules/workSessio
 import { CreateWorkSessionServiceReturnDto } from '../../src/modules/workSession/dto/create-work-session-service-return-dto';
 import { WorkSession } from '../../src/modules/workSession/entity/workSession.entity';
 import { fakeWorkSession } from '../factory/workSession.factory';
-import { GetWorkSessionByUserIdDto } from 'src/modules/workSession/dto/getWorkSessionByUserId.dto';
+import { getWorkSessionsByUserIdDto } from 'src/modules/workSession/dto/getWorkSessionByUserId.dto';
 import { UpdateActiveTaskServiceDto } from 'src/modules/workSession/dto/update-active-task-service.dto';
 
 @injectable()
@@ -26,8 +26,8 @@ export class FakeWorkSessionService implements IWorkSessionService {
     });
   }
 
-  getWorkSessionByUserId(
-    getWorkSessionNyUserIdDto: GetWorkSessionByUserIdDto,
+  getWorkSessionsByUserId(
+    getWorkSessionNyUserIdDto: getWorkSessionsByUserIdDto,
   ): Promise<WorkSession[]> {
     return Promise.resolve([fakeWorkSession()]);
   }


### PR DESCRIPTION
<!--

Title Naming Conventions:

- Start with a capitalized prefix followed by an imperative form of a verb, just like a commit message.
- Refer to the "Commit Convention" for the prefix:
  https://github.com/genesis-tech-tribe/Time-Tracker-frontend/blob/develop/docs/CONTRIBUTING.md#commit-convention.

Example:
- Fix: Resolve memory leak in data processing module
- Feat: Add two-factor authentication
- Refactor: Improve state management in React components
- Docs: Add Windows setup instructions

-->

## Overview

<!-- Provide a brief description of the changes introduced by this PR. -->
- Added new API which get list of workSessions by userId.

## Changes

<!-- List the changes -->
<!-- Delete this section if not needed -->

- Added necessary functions to worksession interface,service, repository.
- Added `/` GET route in workSession controller.
- Added necessary dto files.
