### PR TITLE
Feat : add isPaused to workSession entity

### DIFF
--- a/src/migrations/1706252273011-table-init.ts
+++ b/src/migrations/1706252273011-table-init.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class TableInit1706252273011 implements MigrationInterface {
+    name = 'TableInit1706252273011'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "work_sessions" ADD "isPaused" boolean NOT NULL DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "work_sessions" DROP COLUMN "isPaused"`);
+    }
+
+}

--- a/src/modules/workSession/controller/workSession.controller.ts
+++ b/src/modules/workSession/controller/workSession.controller.ts
@@ -36,7 +36,7 @@ export class WorkSessionController {
   ) {
     const dto = new getWorkSessionsByUserIdDto();
     dto.userId = userId;
-    const workSessions = await this.workSessionService.getWorkSessionByUserId(
+    const workSessions = await this.workSessionService.getWorkSessionsByUserId(
       dto,
     );
 

--- a/src/modules/workSession/entity/workSession.entity.ts
+++ b/src/modules/workSession/entity/workSession.entity.ts
@@ -25,6 +25,9 @@ export class WorkSession {
   @Column({ name: 'end_at', nullable: true, type: 'timestamp' })
   endAt: Date;
 
+  @Column({ name: 'isPaused', nullable: false, default: false })
+  isPaused: boolean;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 


### PR DESCRIPTION
<!--

Title Naming Conventions:

- Start with a capitalized prefix followed by an imperative form of a verb, just like a commit message.
- Refer to the "Commit Convention" for the prefix:
  https://github.com/genesis-tech-tribe/Time-Tracker-frontend/blob/develop/docs/CONTRIBUTING.md#commit-convention.

Example:
- Fix: Resolve memory leak in data processing module
- Feat: Add two-factor authentication
- Refactor: Improve state management in React components
- Docs: Add Windows setup instructions

-->

## Overview

<!-- Provide a brief description of the changes introduced by this PR. -->
- Added `isPaused` property to workSession entity.

## Changes

<!-- List the changes -->
<!-- Delete this section if not needed -->

<!-- Provide a brief description of the changes introduced by this PR. -->
- Added `isPaused` property to workSession entity.
- Generated new migration file
- Fixed `getWorkSessionByUserId` to `getWorkSessionsByUserId` in `workSessionController.ts`
