### PR TITLE
fix:get relations on getting workSession by id

### DIFF
--- a/src/modules/workSession/repository/workSession.repository.ts
+++ b/src/modules/workSession/repository/workSession.repository.ts
@@ -71,7 +71,6 @@ export class WorkSessionRepository implements IWorkSessionRepository {
         userId,
       })
       .getMany();
-    console.log(workSessions);
 
     return workSessions;
   }
@@ -209,7 +208,6 @@ export class WorkSessionRepository implements IWorkSessionRepository {
       const updatedWorkSession = await queryRunner.manager.save(
         savedWorkSession,
       );
-      console.log(updatedWorkSession);
 
       await queryRunner.commitTransaction();
       return updatedWorkSession;


### PR DESCRIPTION
<!--

Title Naming Conventions:

- Start with a capitalized prefix followed by an imperative form of a verb, just like a commit message.
- Refer to the "Commit Convention" for the prefix:
  https://github.com/genesis-tech-tribe/Time-Tracker-frontend/blob/develop/docs/CONTRIBUTING.md#commit-convention.

Example:
- Fix: Resolve memory leak in data processing module
- Feat: Add two-factor authentication
- Refactor: Improve state management in React components
- Docs: Add Windows setup instructions

-->

## Overview

<!-- Provide a brief description of the changes introduced by this PR. -->
Fix `findOnesById` method in workSession repository to get relations